### PR TITLE
Add some missing intrinsic functions

### DIFF
--- a/src/cfn_yaml/core.clj
+++ b/src/cfn_yaml/core.clj
@@ -98,8 +98,11 @@
       (throw (ex-info (str "Unresolved references found: " unresolved-references)
                       {:unresolved unresolved-references})))))
 
+(defn parse* [yml]
+  (yaml/decode (.load (make-yaml) yml) true))
+
 (defn parse [yml]
-  (let [cfn (yaml/decode (.load (make-yaml) yml) true)]
+  (let [cfn (parse* yml)]
     (validate-references cfn)
     cfn))
 

--- a/src/cfn_yaml/core.clj
+++ b/src/cfn_yaml/core.clj
@@ -106,9 +106,12 @@
     (validate-references cfn)
     cfn))
 
+(defn generate-string* [cfn-data]
+  (.dump (make-yaml) (yaml/encode cfn-data)))
+
 (defn generate-string [cfn-data]
   (validate-references cfn-data)
-  (.dump (make-yaml) (yaml/encode cfn-data)))
+  (generate-string* cfn-data))
 
 (defn parse-and-print [filename]
   (println (.dump (make-yaml) (yaml/encode (parse (slurp filename))))))

--- a/src/cfn_yaml/tags/api.clj
+++ b/src/cfn_yaml/tags/api.clj
@@ -12,3 +12,6 @@
 
 (defn !Base64 [valueToEncode]
   (tags/->!Base64 valueToEncode))
+
+(defn !FindInMap [mapName topLevelKey secondLevelKey]
+  (tags/->!FindInMap mapName topLevelKey secondLevelKey))

--- a/src/cfn_yaml/tags/api.clj
+++ b/src/cfn_yaml/tags/api.clj
@@ -15,3 +15,6 @@
 
 (defn !FindInMap [mapName topLevelKey secondLevelKey]
   (tags/->!FindInMap mapName topLevelKey secondLevelKey))
+
+(defn !GetAtt [logicalNameOfResource attributeName]
+  (tags/->!GetAtt logicalNameOfResource attributeName))

--- a/src/cfn_yaml/tags/api.clj
+++ b/src/cfn_yaml/tags/api.clj
@@ -18,3 +18,6 @@
 
 (defn !GetAtt [logicalNameOfResource attributeName]
   (tags/->!GetAtt logicalNameOfResource attributeName))
+
+(defn !Join [delimiter list-of-values]
+  (tags/->!Join delimiter list-of-values))

--- a/test/unit/cfn_yaml/core_test.clj
+++ b/test/unit/cfn_yaml/core_test.clj
@@ -126,3 +126,13 @@ Resources:
 (deftest get-att-gen
   (is (= "!GetAtt 'myELB.DNSName'\n"
          (sut/generate-string (!GetAtt "myELB" "DNSName")))))
+
+
+(deftest join-attr
+  (is (= (!Join ":" [(!Ref "AWS::StackName") "ECSTaskExecutionRole"])
+         (sut/parse* "!Join [ ':', [ !Ref 'AWS::StackName', 'ECSTaskExecutionRole']]"))))
+
+;; TODO don't know how to generate vectors
+#_(deftest join-attr-gen
+  (is (= "!Join [ ':', [ !Ref 'AWS::StackName', 'ECSTaskExecutionRole' ] ]"
+         (sut/generate-string* (!Join ":" [(!Ref "AWS::StackName") "ECSTaskExecutionRole"])))))

--- a/test/unit/cfn_yaml/core_test.clj
+++ b/test/unit/cfn_yaml/core_test.clj
@@ -118,3 +118,11 @@ Resources:
   (is (= "!FindInMap [\"SubnetConfig\", \"VPC\", \"CIDR\"]\n"
          (sut/generate-string (!FindInMap "SubnetConfig" "VPC" "CIDR")))))
 
+
+(deftest get-att
+  (is (= (!GetAtt "myELB" "DNSName")
+         (sut/parse* "!GetAtt myELB.DNSName"))))
+
+(deftest get-att-gen
+  (is (= "!GetAtt 'myELB.DNSName'\n"
+         (sut/generate-string (!GetAtt "myELB" "DNSName")))))

--- a/test/unit/cfn_yaml/core_test.clj
+++ b/test/unit/cfn_yaml/core_test.clj
@@ -106,3 +106,15 @@ Resources:
 (deftest cidr
   (is (= (!Cidr "192.168.0.0/24" 6 5)
          (sut/parse "!Cidr [ \"192.168.0.0/24\", 6, 5 ]"))))
+
+(deftest find-in-map
+  (is (= (!FindInMap "SubnetConfig" (!Ref "AWS::Region") "CIDR")
+         (sut/parse* "!FindInMap ['SubnetConfig', !Ref 'AWS::Region', 'CIDR']")))
+
+  (is (= (!FindInMap "SubnetConfig" "VPC" "CIDR")
+         (sut/parse "!FindInMap ['SubnetConfig', 'VPC', 'CIDR']"))))
+
+(deftest find-in-map-gen
+  (is (= "!FindInMap [\"SubnetConfig\", \"VPC\", \"CIDR\"]\n"
+         (sut/generate-string (!FindInMap "SubnetConfig" "VPC" "CIDR")))))
+


### PR DESCRIPTION
Thank you for sharing this library! Before I was never able to parse AWS Cloudformation YAML with Clojure.

I've added some missing functions (from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html):`!FindInMap`, `!GetAtt`, `!Join`

I didn't figure out how to build a representer for `!Join`.

I also have [another branch](https://github.com/jeroenvandijk/cfn-yaml/tree/feature/to-edn) that removes reflection warnings and compiles with GraalVM (unfortunately it fails to work with custom tags in a native image for unknown reasons)